### PR TITLE
Attachment upload

### DIFF
--- a/content.go
+++ b/content.go
@@ -189,7 +189,7 @@ func (a *API) UpdateContent(c *Content) (*Content, error) {
 // UploadAttachment uploaded the given reader as an attachment to the
 // page with the given id, if the attachment exists it will be updated with
 // a new version number
-func (a *API) UploadAttachment(id string, attachmentName string, attachment io.Reader) (*Content, error) {
+func (a *API) UploadAttachment(id string, attachmentName string, attachment io.Reader) (*Search, error) {
 	ep, err := a.getContentChildEndpoint(id, "attachment")
 	if err != nil {
 		return nil, err

--- a/content.go
+++ b/content.go
@@ -2,6 +2,7 @@ package goconfluence
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -183,6 +184,17 @@ func (a *API) UpdateContent(c *Content) (*Content, error) {
 		return nil, err
 	}
 	return a.SendContentRequest(ep, "PUT", c)
+}
+
+// UploadAttachment uploaded the given reader as an attachment to the
+// page with the given id, if the attachment exists it will be updated with
+// a new version number
+func (a *API) UploadAttachment(id string, attachmentName string, attachment io.Reader) (*Content, error) {
+	ep, err := a.getContentChildEndpoint(id, "attachment")
+	if err != nil {
+		return nil, err
+	}
+	return a.SendContentAttachmentRequest(ep, attachmentName, attachment, map[string]string{})
 }
 
 // DelContent deletes content by id

--- a/content_test.go
+++ b/content_test.go
@@ -103,9 +103,9 @@ func TestContent(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, &Content{}, c)
 
-	c, err = api.UploadAttachment("43", "attachmentName", strings.NewReader("attachment content"))
+	s, err := api.UploadAttachment("43", "attachmentName", strings.NewReader("attachment content"))
 	assert.Nil(t, err)
-	assert.Equal(t, &Content{}, c)
+	assert.Equal(t, &Search{}, s)
 
 	c, err = api.UpdateContent(&Content{})
 	assert.Nil(t, err)

--- a/content_test.go
+++ b/content_test.go
@@ -1,6 +1,7 @@
 package goconfluence
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,6 +100,10 @@ func TestContent(t *testing.T) {
 	assert.Nil(t, err)
 
 	c, err := api.CreateContent(&Content{})
+	assert.Nil(t, err)
+	assert.Equal(t, &Content{}, c)
+
+	c, err = api.UploadAttachment("43", "attachmentName", strings.NewReader("attachment content"))
 	assert.Nil(t, err)
 	assert.Equal(t, &Content{}, c)
 

--- a/request.go
+++ b/request.go
@@ -122,7 +122,8 @@ func (a *API) SendContentAttachmentRequest(ep *url.URL, attachmentName string, a
 		return nil, err
 	}
 
-	req.Header.Add("X-Atlassian-Token", "nocheck") // required by api
+	req.Header.Set("X-Atlassian-Token", "nocheck") // required by api
+	req.Header.Set("Content-Type", writer.FormDataContentType())
 	// https://developer.atlassian.com/cloud/confluence/rest/#api-api-content-id-child-attachment-put
 
 	res, err := a.Request(req)

--- a/request.go
+++ b/request.go
@@ -105,6 +105,9 @@ func (a *API) SendContentAttachmentRequest(ep *url.URL, attachmentName string, a
 
 	// add attachment to body
 	_, err = io.Copy(part, attachment)
+	if err != nil {
+		return nil, err
+	}
 
 	// add any other params
 	for key, val := range params {

--- a/request.go
+++ b/request.go
@@ -1,10 +1,12 @@
 package goconfluence
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strings"
@@ -74,6 +76,54 @@ func (a *API) SendContentRequest(ep *url.URL, method string, c *Content) (*Conte
 	if body != nil {
 		req.Header.Add("Content-Type", "application/json")
 	}
+
+	res, err := a.Request(req)
+	if err != nil {
+		return nil, err
+	}
+
+	var content Content
+
+	err = json.Unmarshal(res, &content)
+	if err != nil {
+		return nil, err
+	}
+
+	return &content, nil
+}
+
+// SendContentAttachmentRequest sends a multipart/form-data attachment create/update request to a content
+func (a *API) SendContentAttachmentRequest(ep *url.URL, attachmentName string, attachment io.Reader, params map[string]string) (*Content, error) {
+	// setup body for mulitpart file, adding minorEdit option
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	writer.WriteField("minorEdit", "true")
+	part, err := writer.CreateFormFile("file", attachmentName)
+	if err != nil {
+		return nil, err
+	}
+
+	// add attachment to body
+	_, err = io.Copy(part, attachment)
+
+	// add any other params
+	for key, val := range params {
+		_ = writer.WriteField(key, val)
+	}
+
+	//clean up multipart form writer
+	err = writer.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("PUT", ep.String(), body) // will always be put
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("X-Atlassian-Token", "nocheck") // required by api
+	// https://developer.atlassian.com/cloud/confluence/rest/#api-api-content-id-child-attachment-put
 
 	res, err := a.Request(req)
 	if err != nil {

--- a/request.go
+++ b/request.go
@@ -93,7 +93,7 @@ func (a *API) SendContentRequest(ep *url.URL, method string, c *Content) (*Conte
 }
 
 // SendContentAttachmentRequest sends a multipart/form-data attachment create/update request to a content
-func (a *API) SendContentAttachmentRequest(ep *url.URL, attachmentName string, attachment io.Reader, params map[string]string) (*Content, error) {
+func (a *API) SendContentAttachmentRequest(ep *url.URL, attachmentName string, attachment io.Reader, params map[string]string) (*Search, error) {
 	// setup body for mulitpart file, adding minorEdit option
 	body := &bytes.Buffer{}
 	writer := multipart.NewWriter(body)
@@ -131,14 +131,14 @@ func (a *API) SendContentAttachmentRequest(ep *url.URL, attachmentName string, a
 		return nil, err
 	}
 
-	var content Content
+	var search Search
 
-	err = json.Unmarshal(res, &content)
+	err = json.Unmarshal(res, &search)
 	if err != nil {
 		return nil, err
 	}
 
-	return &content, nil
+	return &search, nil
 }
 
 // SendUserRequest sends user related requests

--- a/request_test.go
+++ b/request_test.go
@@ -97,7 +97,7 @@ func TestSendContentAttachmentRequest(t *testing.T) {
 	api, err := NewAPI(server.URL+"/wiki/rest/api", "userame", "token")
 	assert.Nil(t, err)
 
-	ep, err := api.getContentEndpoint()
+	ep, err := api.getContentChildEndpoint("43", "attachment")
 	assert.Nil(t, err)
 
 	r1 := strings.NewReader("some test file attachment, normally this would come from a file")


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include unit tests.

Contributors guide: https://github.com/cseeger-epages/confluence-go-api/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `mage test` passes
- [x] unit tests are included and tested
- [x] documentation is added or changed

Documentation is auto generated from comments, so I assume that is fulfilled. I needed the ability to upload attachments to a page. Since it uses the special multipart/form-data it needed a whole new function built out. Unit tests added and has been integration tested independently. Works as expected where you can feed it a io reader with whatever data you want. I've tried strings and png files personally. 
