### PR TITLE
Repair and improve attachment functionality

### DIFF
--- a/content.go
+++ b/content.go
@@ -187,10 +187,19 @@ func (a *API) UpdateContent(c *Content) (*Content, error) {
 }
 
 // UploadAttachment uploaded the given reader as an attachment to the
-// page with the given id, if the attachment exists it will be updated with
+// page with the given id. The existing attachment won't be updated with
 // a new version number
 func (a *API) UploadAttachment(id string, attachmentName string, attachment io.Reader) (*Search, error) {
 	ep, err := a.getContentChildEndpoint(id, "attachment")
+	if err != nil {
+		return nil, err
+	}
+	return a.SendContentAttachmentRequest(ep, attachmentName, attachment, map[string]string{})
+}
+
+// UpdateAttachment update the attachment with an attachmentId on a page with an id to a new version
+func (a *API) UpdateAttachment(id string, attachmentName string, attachmentId string, attachment io.Reader) (*Search, error) {
+	ep, err := a.getContentChildEndpoint(id, "attachment/"+attachmentId+"/data")
 	if err != nil {
 		return nil, err
 	}

--- a/content_test.go
+++ b/content_test.go
@@ -107,6 +107,10 @@ func TestContent(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, &Search{}, s)
 
+	s, err = api.UpdateAttachment("43", "attachmentName", "123", strings.NewReader("attachment content"))
+	assert.Nil(t, err)
+	assert.Equal(t, &Search{}, s)
+
 	c, err = api.UpdateContent(&Content{})
 	assert.Nil(t, err)
 	assert.Equal(t, &Content{}, c)

--- a/request.go
+++ b/request.go
@@ -120,7 +120,7 @@ func (a *API) SendContentAttachmentRequest(ep *url.URL, attachmentName string, a
 		return nil, err
 	}
 
-	req, err := http.NewRequest("PUT", ep.String(), body) // will always be put
+	req, err := http.NewRequest("POST", ep.String(), body) // will always be put
 	if err != nil {
 		return nil, err
 	}

--- a/request_test.go
+++ b/request_test.go
@@ -326,6 +326,8 @@ func confluenceRestAPIStub() *httptest.Server {
 			resp = Search{}
 		case "/wiki/rest/api/content/42/child/attachment":
 			resp = Search{}
+		case "/wiki/rest/api/content/43/child/attachment/123/data":
+			resp = Search{}
 		case "/wiki/rest/api/content/43/child/attachment":
 			resp = Content{}
 		case "/wiki/rest/api/content/42/child/comment":

--- a/structs.go
+++ b/structs.go
@@ -14,6 +14,9 @@ type API struct {
 
 // Results array
 type Results struct {
+	ID      string  `json:"id,omitempty"`
+	Type    string  `json:"type,omitempty"`
+	Status  string  `json:"status,omitempty"`
 	Content Content `json:"content"`
 	Excerpt string  `json:"excerpt,omitempty"`
 	Title   string  `json:"title,omitempty"`


### PR DESCRIPTION
### Environment
Confluence server version: 7.3.5

### Attachment Upload
According to [the confluence API documentation](https://docs.atlassian.com/atlassian-confluence/REST/6.5.2/?_ga=2.104850052.520898763.1594138097-640546186.1587366519#content/{id}/child/attachment-createAttachments), upload attachment has to be performed with a [POST](https://github.com/cseeger-epages/confluence-go-api/compare/master...iliazlobin:attachments#diff-d9c546c27e20f6a2acfc4ac7b74c1a26R123) HTTP method rather than [PUT](https://github.com/cseeger-epages/confluence-go-api/compare/master...iliazlobin:attachments#diff-d9c546c27e20f6a2acfc4ac7b74c1a26L123).

Use this curl command to check the functionality:
```
curl -v -S -u username:password -X POST -H "X-Atlassian-Token: no-check" -F "file=@file.xlsx" "https://confluence.url/rest/api/content/224890031/child/attachment" | jq
```

### Attachment Update
The UploadAttachment method doesn't follow [its documentation](https://github.com/cseeger-epages/confluence-go-api/blob/master/content.go#L189-L198) of new attachments being updated (at least for my confluence server v7.3.5).

[The official API doc](https://docs.atlassian.com/atlassian-confluence/REST/6.5.2/?_ga=2.104850052.520898763.1594138097-640546186.1587366519#content/{id}/child/attachment-updateData) indicates that a valid endpoint for this action happens to be `.../attachment/123/data`. [A new method](https://github.com/cseeger-epages/confluence-go-api/compare/master...iliazlobin:attachments#diff-7e86c3a300b87b72f38deac882a9783cR200-R207) introduced for the update operation.

To obtain an update action, you can use the following code function:
```
func (c *Client) UpdateAttachment(name string, file *bytes.Reader, page *Page) (*goconfluence.Search, error) {
	attachments, err := c.Api.GetAttachments(page.Id)
	if err != nil {
		return nil, err
	}

	attachmentId := ""
	for _, r := range attachments.Results {
		if name == r.Title {
			attachmentId = r.ID
			break
		}
	}

	if attachmentId != "" {
		log.Printf("[INFO] Updating attachment %s on page %s/%s", name, page.Space, page.Title)
		attachment, err := c.Api.UpdateAttachment(page.Id, name, attachmentId, file)
		if err != nil {
			return nil, err
		}
		return attachment, nil
	}

	log.Printf("[INFO] Creating attachment %s on page %s/%s", name, page.Space, page.Title)
	attachment, err := c.Api.UploadAttachment(page.Id, name, file)
	return attachment, nil
}
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [v] `mage test` passes
- [v] unit tests are included and tested
- [v] documentation is added or changed

### Temporary Workaround
[I forked a repo](https://github.com/iliazlobin/confluence-go-api/commits/master), changed a module path, and made a module temporarily being available using the following import line:
```
require (
	github.com/iliazlobin/confluence-go-api v1.1.1-0.20200707195312-b4dfe8e8a1c4
// ...
```